### PR TITLE
fix: adjust padding in mobile completed workshops carousel

### DIFF
--- a/src/app/workshops/mobile-completed-workshops-carousel.tsx
+++ b/src/app/workshops/mobile-completed-workshops-carousel.tsx
@@ -143,7 +143,7 @@ function MobileCompletedWorkshopsCarousel() {
             return (
               <OpacityCarouselSlide
                 key={index}
-                className="max-w-[60%] basis-[60%] overflow-hidden pl-2.5"
+                className="max-w-[60%] basis-[60%] overflow-hidden pl-3"
               >
                 <div className="w-full max-w-full">
                   <div className="flex cursor-pointer flex-col items-center justify-center">
@@ -173,7 +173,7 @@ function MobileCompletedWorkshopsCarousel() {
                       </div>
                     </div>
 
-                    <p className="line-clamp-4 max-w-[176px] overflow-hidden break-all font-primary text-sm font-bold text-[#173552]">
+                    <p className="line-clamp-4 overflow-hidden break-all font-primary text-sm font-bold text-[#173552]">
                       {itm.workshopName}
                     </p>
                   </div>


### PR DESCRIPTION
This pull request includes minor updates to the `MobileCompletedWorkshopsCarousel` component in the `src/app/workshops/mobile-completed-workshops-carousel.tsx` file. These changes adjust the styling of the component to improve its layout and appearance.

Styling adjustments:

* Modified the padding-left property of the `OpacityCarouselSlide` component to `pl-3` for better spacing.
* Removed the `max-w-[176px]` class from the paragraph element to allow for more flexible width handling.